### PR TITLE
changes default notifier to not create user_link for unknown user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,25 @@ Heaven currently supports [Capistrano][15], [Fabric][10], and [Heroku][22] deplo
 * [Deployment Notifications](/doc/notifications.md)
 * [Environment Locking](/doc/locking.md)
 
-# Launch on Heroku
+## Making changes to our version of Heaven
 
-[![Launch on Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+To make any changes to Heaven, you'll need Docker installed locally.
+
+First, make you changes to Heaven and open a pull request. Then:
+
+push your local changes to Docker:
+
+```(sh)
+cd heaven
+script/release
+```
+
+Then deploy the latest Docker image to our environment:
+
+```(sh)
+cd aws-deploy-brainy
+script/deploy production heaven -t heaven
+```
 
 [1]: http://developer.github.com/v3/repos/deployments/
 [2]: https://github.com/blog/1778-webhooks-level-up

--- a/lib/heaven/notifier/default.rb
+++ b/lib/heaven/notifier/default.rb
@@ -190,7 +190,9 @@ module Heaven
       end
 
       def user_link
-        "[#{chat_user}](#{octokit_web_endpoint}#{chat_user})"
+        # don't create user_link if user is unknown
+        return "#{chat_user}" if ["unknown", "autodeploy"].include?chat_user
+        "[#{chat_user}](#{octokit_web_endpoint}#{chat_user})" 
       end
 
       def output_link(link_title = "deployment")

--- a/spec/lib/heaven/notifier/default_spec.rb
+++ b/spec/lib/heaven/notifier/default_spec.rb
@@ -16,15 +16,26 @@ describe "Heaven::Notifier::Default" do
       expect(notifier.chat_user).to eq("sarahconnor")
     end
 
-    it "returns unknown chat user if payload is empty" do
-      data = { "deployment" => {
-        "payload" => {}
+    context "unkown chat user" do
+      it "returns unknown chat user if payload is empty" do
+        data = { "deployment" => {
+          "payload" => {}
+          }
         }
-      }
-      notifier = Heaven::Notifier::Default.new(data)
-      expect(notifier.chat_user).to eq("unknown")
-    end
+        notifier = Heaven::Notifier::Default.new(data)
+        expect(notifier.chat_user).to eq("unknown")
+      end
 
+      it "does not generate a user_link if user is unknown or 'autodeploy'" do
+        data = { "state" => "success",
+          "deployment" => {
+          "payload" => {}
+          }
+        }
+        notifier = Heaven::Notifier::Default.new(data)
+        expect(notifier.user_link).to eq("unknown")
+      end
+    end
   end
 
   it "does not deliver changes unless an environment opt-in is present" do


### PR DESCRIPTION
[ch15704]
the link is confusing if the user is unknown.
Also updates readme.