### PR TITLE
Update Notifier for better default message

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Heaven
     logger.formatter = ::Logger::Formatter.new
 
     config.logger = ActiveSupport::TaggedLogging.new(logger)
-    config.log_level = ENV["HEAVEN_LOG_LEVEL"] || :debug
+    config.log_level = ENV["HEAVEN_LOG_LEVEL"] || :info
 
     config.serve_static_files = true
     config.action_dispatch.x_sendfile_header = nil

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,7 +1,4 @@
-# param_keys =  [:branches, :commit, :config, :context, :deployment, :description, :environment, :id, :name, :password, :payload, :ref, :repository, :sender, :sha, :state, :target_url]
+param_keys =  [:branches, :commit, :config, :context, :deployment, :description, :environment, :id, :name, :password, :payload, :ref, :repository, :sender, :sha, :state, :target_url]
 
-# Rails.application.config.filter_parameters += param_keys
+Rails.application.config.filter_parameters += param_keys
 
-# commenting out most keys for now, leaving password
-
-Rails.application.config.filter_parameters += [:password]

--- a/lib/heaven/notifier/default.rb
+++ b/lib/heaven/notifier/default.rb
@@ -105,8 +105,7 @@ module Heaven
       end
 
       def chat_user
-        return "unknown" unless deployment_payload["notify"]
-        deployment_payload["notify"]["user_name"] || deployment_payload["notify"]["user"] || "unknown"
+        deployment_payload["actor"] || "unknown"
       end
 
       def chat_room
@@ -191,7 +190,7 @@ module Heaven
 
       def user_link
         # don't create user_link if user is unknown
-        return "#{chat_user}" if ["unknown", "autodeploy"].include?chat_user
+        return "#{chat_user}" if chat_user == "unknown"
         "[#{chat_user}](#{octokit_web_endpoint}#{chat_user})" 
       end
 

--- a/lib/heaven/notifier/slack.rb
+++ b/lib/heaven/notifier/slack.rb
@@ -28,7 +28,7 @@ module Heaven
 
       def default_message
         message = output_link("##{deployment_number}")
-        message << " : #{user_link}"
+        message << " : #{chat_user}"
         case task
         when "deploy"
           message << deploy_message

--- a/spec/fixtures/deployment-capistrano.json
+++ b/spec/fixtures/deployment-capistrano.json
@@ -8,6 +8,7 @@
     "payload": {
       "name": "example-repo",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "example:room",
         "user": "Mumakil",

--- a/spec/fixtures/deployment-failure.json
+++ b/spec/fixtures/deployment-failure.json
@@ -6,9 +6,9 @@
     "id": 123456,
     "sha": "daf81923c94f7513ac840fa4fcc0dfcc11f32f74",
     "ref": "break-up-notifiers",
+    "task": "deploy",
     "payload": {
       "name": "my-robot",
-      "task": "deploy",
       "hosts": "",
       "actor": "atmos",
       "notify": {

--- a/spec/fixtures/deployment-failure.json
+++ b/spec/fixtures/deployment-failure.json
@@ -10,6 +10,7 @@
       "name": "my-robot",
       "task": "deploy",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "danger",
         "user": "atmos",

--- a/spec/fixtures/deployment-pending.json
+++ b/spec/fixtures/deployment-pending.json
@@ -6,9 +6,9 @@
     "id": 123456,
     "sha": "daf81923c94f7513ac840fa4fcc0dfcc11f32f74",
     "ref": "break-up-notifiers",
+    "task": "deploy",
     "payload": {
       "name": "my-robot",
-      "task": "deploy",
       "hosts": "",
       "actor": "atmos",
       "notify": {

--- a/spec/fixtures/deployment-pending.json
+++ b/spec/fixtures/deployment-pending.json
@@ -10,6 +10,7 @@
       "name": "my-robot",
       "task": "deploy",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "danger",
         "user": "atmos",

--- a/spec/fixtures/deployment-success.json
+++ b/spec/fixtures/deployment-success.json
@@ -6,9 +6,9 @@
     "id": 11627,
     "sha": "daf81923c94f7513ac840fa4fcc0dfcc11f32f74",
     "ref": "break-up-notifiers",
+    "task": "deploy",
     "payload": {
       "name": "my-robot",
-      "task": "deploy",
       "hosts": "",
       "actor": "atmos",
       "notify": {

--- a/spec/fixtures/deployment-success.json
+++ b/spec/fixtures/deployment-success.json
@@ -10,6 +10,7 @@
       "name": "my-robot",
       "task": "deploy",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "danger",
         "user": "atmos",

--- a/spec/fixtures/deployment.json
+++ b/spec/fixtures/deployment.json
@@ -8,6 +8,7 @@
     "payload": {
       "name": "my-robot",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "ops",
         "user": "atmos",

--- a/spec/fixtures/deployment_staging.json
+++ b/spec/fixtures/deployment_staging.json
@@ -8,6 +8,7 @@
     "payload": {
       "name": "heaven",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "ops",
         "user": "atmos",

--- a/spec/fixtures/deployment_turnkey.json
+++ b/spec/fixtures/deployment_turnkey.json
@@ -8,6 +8,7 @@
     "payload": {
       "name": "heaven",
       "hosts": "",
+      "actor": "atmos",
       "notify": {
         "room": "ops",
         "user": "atmos",

--- a/spec/lib/heaven/notifier/default_spec.rb
+++ b/spec/lib/heaven/notifier/default_spec.rb
@@ -6,35 +6,33 @@ describe "Heaven::Notifier::Default" do
       data = {
         "deployment" => {
           "payload" => {
-            "notify" => {
-              "user_name" => "sarahconnor"
-            }
+            "actor" => "sarahconnor"
           }
         }
       }
+      
       notifier = Heaven::Notifier::Default.new(data)
       expect(notifier.chat_user).to eq("sarahconnor")
     end
 
-    context "unkown chat user" do
-      it "returns unknown chat user if payload is empty" do
-        data = { "deployment" => {
-          "payload" => {}
-          }
+    it "returns unknown chat user if payload is empty" do
+      data = { "deployment" => {
+        "payload" => {}
         }
-        notifier = Heaven::Notifier::Default.new(data)
-        expect(notifier.chat_user).to eq("unknown")
-      end
+      }
+      notifier = Heaven::Notifier::Default.new(data)
+      expect(notifier.chat_user).to eq("unknown")
+    end
+  end
 
-      it "does not generate a user_link if user is unknown or 'autodeploy'" do
-        data = { "state" => "success",
-          "deployment" => {
-          "payload" => {}
-          }
+  context "user_link" do
+    it "does not generate a user_link if user is 'unknown'" do
+      data = { "deployment" => {
+        "payload" => {}
         }
-        notifier = Heaven::Notifier::Default.new(data)
-        expect(notifier.user_link).to eq("unknown")
-      end
+      }
+      notifier = Heaven::Notifier::Default.new(data)
+      expect(notifier.user_link).to eq("unknown")
     end
   end
 

--- a/spec/lib/heaven/notifier/slack_spec.rb
+++ b/spec/lib/heaven/notifier/slack_spec.rb
@@ -24,36 +24,36 @@ describe "Heaven::Notifier::Slack" do
 
     result = [
       "[#123456](https://gist.github.com/fa77d9fb1fe41c3bb3a3ffb2c) ",
-      ": [atmos](https://github.com/atmos) is deploying ",
+      ": atmos is deploying ",
       "[my-robot](https://github.com/atmos/my-robot/tree/break-up-notifiers) ",
       "to production ([compare](https://github.com/org/repo/compare/sha...sha))"
     ]
-
+    
     expect(n.default_message).to eql result.join("")
   end
 
-  it "handles successful deployment statuses" do
+  xit "handles successful deployment statuses" do
     data = decoded_fixture_data("deployment-success")
 
     n = Heaven::Notifier::Slack.new(data)
 
     result = [
       "[#11627](https://gist.github.com/fa77d9fb1fe41c3bb3a3ffb2c) ",
-      ": [atmos](https://github.com/atmos)'s production deployment of ",
+      ": atmos's production deployment of ",
       "[my-robot](https://github.com/atmos/my-robot) ",
       "is done! "
     ]
     expect(n.default_message).to eql result.join("")
   end
 
-  it "handles failure deployment statuses" do
+  xit "handles failure deployment statuses" do
     data = decoded_fixture_data("deployment-failure")
 
     n = Heaven::Notifier::Slack.new(data)
 
     result = [
       "[#123456](https://gist.github.com/fa77d9fb1fe41c3bb3a3ffb2c) ",
-      ": [atmos](https://github.com/atmos)'s production deployment of ",
+      ": atmos's production deployment of ",
       "[my-robot](https://github.com/atmos/my-robot) ",
       "failed. "
     ]

--- a/spec/lib/heaven/notifier/slack_spec.rb
+++ b/spec/lib/heaven/notifier/slack_spec.rb
@@ -17,8 +17,8 @@ describe "Heaven::Notifier::Slack" do
 
     data = decoded_fixture_data("deployment-pending")
 
-    n = Heaven::Notifier::Slack.new(data)
-    n.comparison = {
+    notifier = Heaven::Notifier::Slack.new(data)
+    notifier.comparison = {
       "html_url" => "https://github.com/org/repo/compare/sha...sha"
     }
 
@@ -29,13 +29,13 @@ describe "Heaven::Notifier::Slack" do
       "to production ([compare](https://github.com/org/repo/compare/sha...sha))"
     ]
     
-    expect(n.default_message).to eql result.join("")
+    expect(notifier.default_message).to eql result.join("")
   end
 
-  xit "handles successful deployment statuses" do
+  it "handles successful deployment statuses" do
     data = decoded_fixture_data("deployment-success")
 
-    n = Heaven::Notifier::Slack.new(data)
+    notifier = Heaven::Notifier::Slack.new(data)
 
     result = [
       "[#11627](https://gist.github.com/fa77d9fb1fe41c3bb3a3ffb2c) ",
@@ -43,13 +43,13 @@ describe "Heaven::Notifier::Slack" do
       "[my-robot](https://github.com/atmos/my-robot) ",
       "is done! "
     ]
-    expect(n.default_message).to eql result.join("")
+    expect(notifier.default_message).to eql result.join("")
   end
 
-  xit "handles failure deployment statuses" do
+  it "handles failure deployment statuses" do
     data = decoded_fixture_data("deployment-failure")
 
-    n = Heaven::Notifier::Slack.new(data)
+    notifier = Heaven::Notifier::Slack.new(data)
 
     result = [
       "[#123456](https://gist.github.com/fa77d9fb1fe41c3bb3a3ffb2c) ",
@@ -57,6 +57,6 @@ describe "Heaven::Notifier::Slack" do
       "[my-robot](https://github.com/atmos/my-robot) ",
       "failed. "
     ]
-    expect(n.default_message).to eql result.join("")
+    expect(notifier.default_message).to eql result.join("")
   end
 end


### PR DESCRIPTION
Currently we are seeing "unknown" as the user when Heaven notifies on a deploy kicked off through our CI (through lita) because the deploy doesn't have a "notify" section of the deployment payload. 
The notifier also creates a user link in the default message that is not useful and often wrong.

This PR uses "actor" to set the chat_user, and changes the default message for the Slack notifier to user chat_user instead of user_link.